### PR TITLE
PR2: Add User Role Metadata Support with Owner/Contributor Differentiation

### DIFF
--- a/label_studio/organizations/serializers.py
+++ b/label_studio/organizations/serializers.py
@@ -83,7 +83,7 @@ class OrganizationMemberSerializer(DynamicFieldsMixin, serializers.ModelSerializ
         user_role = getattr(member.user, 'role', 'owner')
         role_mapping = {
             'owner': 'OW',        # Owner
-            'contributor': 'AN',  # Annotator (closest to contributor)
+            'contributor': 'CO',  # Contributor
         }
         return role_mapping.get(user_role, 'OW')  # Default to Owner
 

--- a/label_studio/organizations/serializers.py
+++ b/label_studio/organizations/serializers.py
@@ -63,6 +63,7 @@ class OrganizationMemberListSerializer(DynamicFieldsMixin, serializers.ModelSeri
 class OrganizationMemberSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
     annotations_count = serializers.SerializerMethodField(read_only=True)
     contributed_projects_count = serializers.SerializerMethodField(read_only=True)
+    role = serializers.SerializerMethodField(read_only=True)
 
     def get_annotations_count(self, member):
         org = self.context.get('organization')
@@ -72,9 +73,23 @@ class OrganizationMemberSerializer(DynamicFieldsMixin, serializers.ModelSerializ
         org = self.context.get('organization')
         return member.user.annotations.filter(project__organization=org).values('project').distinct().count()
 
+    def get_role(self, member):
+        """Map User.role to frontend expected role codes"""
+        # If user is organization owner, always return 'OW' 
+        if member.is_owner:
+            return 'OW'
+        
+        # Map our User.role values to frontend codes
+        user_role = getattr(member.user, 'role', 'owner')
+        role_mapping = {
+            'owner': 'OW',        # Owner
+            'contributor': 'AN',  # Annotator (closest to contributor)
+        }
+        return role_mapping.get(user_role, 'OW')  # Default to Owner
+
     class Meta:
         model = OrganizationMember
-        fields = ['user', 'organization', 'contributed_projects_count', 'annotations_count', 'created_at']
+        fields = ['user', 'organization', 'contributed_projects_count', 'annotations_count', 'created_at', 'role']
 
 
 class OrganizationInviteSerializer(serializers.Serializer):

--- a/label_studio/users/forms.py
+++ b/label_studio/users/forms.py
@@ -26,6 +26,11 @@ FOUND_US_OPTIONS = (
     ('Ot', FOUND_US_ELABORATE),
 )
 
+USER_ROLE_OPTIONS = (
+    ('owner', 'Owner'),
+    ('contributor', 'Contributor'),
+)
+
 logger = logging.getLogger(__name__)
 
 
@@ -64,6 +69,7 @@ class UserSignupForm(forms.Form):
     allow_newsletters = forms.BooleanField(required=False)
     how_find_us = forms.CharField(required=False)
     elaborate = forms.CharField(required=False)
+    role = forms.ChoiceField(choices=USER_ROLE_OPTIONS, initial='owner', required=False)
 
     def clean_password(self):
         password = self.cleaned_data.get('password')
@@ -95,6 +101,8 @@ class UserSignupForm(forms.Form):
         email = cleaned['email'].lower()
         allow_newsletters = None
         how_find_us = None
+        role = cleaned.get('role', 'owner')  # Default to 'owner' if not specified
+        
         if 'allow_newsletters' in cleaned:
             allow_newsletters = cleaned['allow_newsletters']
         if 'how_find_us' in cleaned:
@@ -102,7 +110,7 @@ class UserSignupForm(forms.Form):
         if 'elaborate' in cleaned and how_find_us == FOUND_US_ELABORATE:
             cleaned['elaborate']
 
-        user = User.objects.create_user(email, password, allow_newsletters=allow_newsletters)
+        user = User.objects.create_user(email, password, allow_newsletters=allow_newsletters, role=role)
         return user
 
 

--- a/label_studio/users/migrations/0012_user_role.py
+++ b/label_studio/users/migrations/0012_user_role.py
@@ -1,0 +1,24 @@
+# Generated manually for user role feature
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("users", "0011_user_custom_hotkeys"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="user",
+            name="role",
+            field=models.CharField(
+                choices=[('owner', 'Owner'), ('contributor', 'Contributor')],
+                default='owner',
+                help_text='User role in the organization',
+                max_length=20,
+                verbose_name='user role',
+            ),
+        ),
+    ]

--- a/label_studio/users/models.py
+++ b/label_studio/users/models.py
@@ -27,6 +27,12 @@ for r in range(YEAR_START, (datetime.datetime.now().year + 1)):
 
 year = models.IntegerField(_('year'), choices=YEAR_CHOICES, default=datetime.datetime.now().year)
 
+# User role choices
+USER_ROLE_CHOICES = [
+    ('owner', 'Owner'),
+    ('contributor', 'Contributor'),
+]
+
 
 class UserManager(BaseUserManager):
     use_in_migrations = True
@@ -150,6 +156,14 @@ class User(UserMixin, AbstractBaseUser, PermissionsMixin, UserLastActivityMixin)
         _('allow newsletters'), null=True, default=None, help_text=_('Allow sending newsletters to user')
     )
 
+    role = models.CharField(
+        _('user role'),
+        max_length=20,
+        choices=USER_ROLE_CHOICES,
+        default='owner',
+        help_text=_('User role in the organization')
+    )
+
     objects = UserManager()
 
     EMAIL_FIELD = 'email'
@@ -238,6 +252,10 @@ class User(UserMixin, AbstractBaseUser, PermissionsMixin, UserLastActivityMixin)
         elif self.first_name and self.last_name:
             initials = self.first_name[0:1] + self.last_name[0:1]
         return initials
+
+    def get_pretty_role(self):
+        """Return the display name for the user's role."""
+        return dict(USER_ROLE_CHOICES).get(self.role, self.role.title())
 
 
 @receiver(post_save, sender=User)

--- a/label_studio/users/templates/users/new-ui/user_signup.html
+++ b/label_studio/users/templates/users/new-ui/user_signup.html
@@ -58,6 +58,12 @@
           <option value="owner" {% if not user_form.data.role or user_form.data.role == 'owner' %}selected{% endif %}>Owner</option>
           <option value="contributor" {% if user_form.data.role == 'contributor' %}selected{% endif %}>Contributor</option>
         </select>
+        <!-- Debug: Check if role_options is passed correctly -->
+        {% if role_options %}
+          <small style="color: green;">✓ Role options available: {{ role_options|length }} options</small>
+        {% else %}
+          <small style="color: red;">✗ Role options not found</small>
+        {% endif %}
       </div>
       <div class="input-wrapper" id="elaborateContainer" {% if user_form.data.how_find_us != elaborate %}style="display:none;"{% endif %}> 
         <label>Please elaborate</label>

--- a/label_studio/users/templates/users/new-ui/user_signup.html
+++ b/label_studio/users/templates/users/new-ui/user_signup.html
@@ -58,12 +58,6 @@
           <option value="owner" {% if not user_form.data.role or user_form.data.role == 'owner' %}selected{% endif %}>Owner</option>
           <option value="contributor" {% if user_form.data.role == 'contributor' %}selected{% endif %}>Contributor</option>
         </select>
-        <!-- Debug: Check if role_options is passed correctly -->
-        {% if role_options %}
-          <small style="color: green;">✓ Role options available: {{ role_options|length }} options</small>
-        {% else %}
-          <small style="color: red;">✗ Role options not found</small>
-        {% endif %}
       </div>
       <div class="input-wrapper" id="elaborateContainer" {% if user_form.data.how_find_us != elaborate %}style="display:none;"{% endif %}> 
         <label>Please elaborate</label>

--- a/label_studio/users/templates/users/new-ui/user_signup.html
+++ b/label_studio/users/templates/users/new-ui/user_signup.html
@@ -52,6 +52,13 @@
           {% endfor %}
         </select>
       </div>
+      <div class="input-wrapper">
+        <label>Your Role</label>
+        <select class="lsf-select-ls" name="role" id="role">
+          <option value="owner" {% if not user_form.data.role or user_form.data.role == 'owner' %}selected{% endif %}>Owner</option>
+          <option value="contributor" {% if user_form.data.role == 'contributor' %}selected{% endif %}>Contributor</option>
+        </select>
+      </div>
       <div class="input-wrapper" id="elaborateContainer" {% if user_form.data.how_find_us != elaborate %}style="display:none;"{% endif %}> 
         <label>Please elaborate</label>
         <input class="lsf-input-ls" name="elaborate" id="elaborate" {% if user_form.data.how_find_us == elaborate %}value="{{ user_form.data.elaborate }}"{% endif %}>

--- a/label_studio/users/templates/users/user_signup.html
+++ b/label_studio/users/templates/users/user_signup.html
@@ -30,6 +30,24 @@
       </div>
 
     <div>
+      <label>How did you hear about Label Studio?</label>
+      <select class="lsf-select-ls" name="how_find_us" id="how_find_us">
+        <option disabled value="" {% if not user_form.data.how_find_us %}selected{% endif %}>Select an option</option>
+        {% for choice in found_us_options %}
+          <option value="{{ choice.1 }}" {% if choice.1 == user_form.data.how_find_us %}selected{% endif %}>{{ choice.1 }}</option>
+        {% endfor %}
+      </select>
+    </div>
+
+    <div>
+      <label>Your Role</label>
+      <select class="lsf-select-ls" name="role" id="role">
+        <option value="owner" {% if not user_form.data.role or user_form.data.role == 'owner' %}selected{% endif %}>Owner</option>
+        <option value="contributor" {% if user_form.data.role == 'contributor' %}selected{% endif %}>Contributor</option>
+      </select>
+    </div>
+
+    <div>
       <input name="allow_newsletters" id="allow_newsletters" type="hidden" value="true">
       <label for="allow_newsletters_visual" style="display: inline-block; cursor: pointer;">
 

--- a/label_studio/users/templates/users/user_signup.html
+++ b/label_studio/users/templates/users/user_signup.html
@@ -45,12 +45,6 @@
         <option value="owner" {% if not user_form.data.role or user_form.data.role == 'owner' %}selected{% endif %}>Owner</option>
         <option value="contributor" {% if user_form.data.role == 'contributor' %}selected{% endif %}>Contributor</option>
       </select>
-      <!-- Debug: Check if role_options is passed correctly -->
-      {% if role_options %}
-        <small style="color: green;">✓ Role options available: {{ role_options|length }} options</small>
-      {% else %}
-        <small style="color: red;">✗ Role options not found</small>
-      {% endif %}
     </div>
 
     <div>

--- a/label_studio/users/templates/users/user_signup.html
+++ b/label_studio/users/templates/users/user_signup.html
@@ -45,6 +45,12 @@
         <option value="owner" {% if not user_form.data.role or user_form.data.role == 'owner' %}selected{% endif %}>Owner</option>
         <option value="contributor" {% if user_form.data.role == 'contributor' %}selected{% endif %}>Contributor</option>
       </select>
+      <!-- Debug: Check if role_options is passed correctly -->
+      {% if role_options %}
+        <small style="color: green;">✓ Role options available: {{ role_options|length }} options</small>
+      {% else %}
+        <small style="color: red;">✗ Role options not found</small>
+      {% endif %}
     </div>
 
     <div>

--- a/label_studio/users/views.py
+++ b/label_studio/users/views.py
@@ -85,6 +85,7 @@ def user_signup(request):
                 'token': token,
                 'found_us_options': forms.FOUND_US_OPTIONS,
                 'elaborate': forms.FOUND_US_ELABORATE,
+                'role_options': forms.USER_ROLE_OPTIONS,
             },
         )
 
@@ -96,6 +97,9 @@ def user_signup(request):
             'organization_form': organization_form,
             'next': quote(next_page),
             'token': token,
+            'found_us_options': forms.FOUND_US_OPTIONS,
+            'elaborate': forms.FOUND_US_ELABORATE,
+            'role_options': forms.USER_ROLE_OPTIONS,
         },
     )
 

--- a/web/libs/app-common/src/pages/AccountSettings/sections/MembershipInfo.tsx
+++ b/web/libs/app-common/src/pages/AccountSettings/sections/MembershipInfo.tsx
@@ -59,6 +59,9 @@ export const MembershipInfo = () => {
         case "NO":
           role = "Pending";
           break;
+        case "CO":
+          role = "Contributor";
+          break;
       }
 
       return {


### PR DESCRIPTION
# PR2: Add User Role Metadata Support with Owner/Contributor Differentiation

## 🎯 Overview
This PR implements user role metadata functionality to differentiate between "Owner" and "Contributor" user types in Label Studio. Users can now select their role during registration, and the selected role is properly displayed in their account settings.

## ✨ Key Features
- **Role Selection During Signup**: Added dropdown for users to select their role (Owner/Contributor)
- **Database Storage**: New `role` field in User model with proper migration
- **Account Display**: Selected role correctly shown in user account page

## 📁 Changes Made

### Backend Changes
- **User Model** (`label_studio/users/models.py`)
  - Added `role` CharField with Owner/Contributor choices
  - Added `get_pretty_role()` method for display formatting
  - Default value: `'owner'` for backward compatibility

- **User Forms** (`label_studio/users/forms.py`)
  - Extended `UserSignupForm` with role selection field
  - Updated form save logic to handle role data

- **Database Migration** (`label_studio/users/migrations/0012_user_role.py`)
  - Added migration for new role field
  - Safe migration with default values

- **Organization Serializer** (`label_studio/organizations/serializers.py`)
  - Added role field to `OrganizationMemberSerializer`
  - Proper mapping: Owner → 'OW', Contributor → 'CO'

- **Views** (`label_studio/users/views.py`)
  - Updated signup views to pass role options to templates

### Frontend Changes
- **Signup Templates**
  - **New UI** (`users/new-ui/user_signup.html`): Added role dropdown below "How did you hear about" field
  - **Legacy UI** (`users/user_signup.html`): Added role dropdown with same positioning

- **Account Settings** (`web/libs/app-common/src/pages/AccountSettings/sections/MembershipInfo.tsx`)
  - Added 'CO' → 'Contributor' mapping in role display logic
  - Ensures proper role display in membership info

## 🔄 Change Type
- [x] New Feature
- [x] Database Migration
- [x] UI/UX Enhancement
- [ ] Bug Fix
- [ ] Performance Optimization

## 🧪 Testing & Validation

### Manual Testing Completed
- ✅ Role dropdown appears in both signup forms (new-ui and legacy)
- ✅ User can select Owner or Contributor during registration
- ✅ Selected role is saved to database correctly
- ✅ Role displays properly in account settings page
- ✅ Existing users default to Owner role
- ✅ Database migration runs successfully

### UI Screenshots

#### Registration Page - Role Selection
<!-- Please paste screenshot of the signup form showing the role dropdown here -->
<img width="740" height="960" alt="Screenshot 2025-08-13 at 23 18 18" src="https://github.com/user-attachments/assets/c9700615-da37-4192-bc5b-205f1a83e974" />



*Screenshot showing the "Your Role" dropdown positioned below "How did you hear about Label Studio?" field*

#### Account Page - Role Display  
<!-- Please paste screenshot of the account page showing the role in membership info here -->
<img width="1256" height="774" alt="Screenshot 2025-08-13 at 23 35 02" src="https://github.com/user-attachments/assets/281f55ed-0db7-4616-955b-6f37f40e4a29" />


*Screenshot showing the "My role" field displaying "Contributor" in the membership info section*

## 🔧 Technical Details

### Database Schema
```sql
-- New field added to htx_user table
ALTER TABLE htx_user ADD COLUMN role VARCHAR(20) DEFAULT 'owner';
```

### Role Mapping
| User Selection | Database Value | API Code | Frontend Display |
|---------------|----------------|----------|------------------|
| Owner | `'owner'` | `'OW'` | Owner |
| Contributor | `'contributor'` | `'CO'` | Contributor |

### API Changes
- `GET /api/organizations/{org_id}/memberships/{user_id}` now includes `role` field
- Role field returns appropriate code ('OW', 'CO') based on user selection

## 🎯 Implementation Notes

### Positioning
- Role dropdown is positioned **below** the "How did you hear about Label Studio?" field as requested
- Maintains consistent styling with existing form elements

### Backward Compatibility
- All existing users automatically get `'owner'` role
- No breaking changes to existing functionality
- Organization owners always display as 'Owner' regardless of role field

### Future Considerations
This PR lays the foundation for future permission-based features. The role field can be used to implement:
- Different permission levels
- Feature access control
- UI customization based on role

## 💡 Notes
- This change only adds role metadata and display functionality
- No permission restrictions are implemented in this PR
- Permission-based features will be addressed in future PRs
 
 